### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,14 +6,14 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MotorControl KEYWORD1
+MotorControl	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 drive	KEYWORD2
-init KEYWORD2
+init	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -22,8 +22,8 @@ init KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-FORWARD LITERAL1
-REVERSE LITERAL1
-LEFT LITERAL1
-RIGHT LITERAL1
-STOP LITERAL1
+FORWARD	LITERAL1
+REVERSE	LITERAL1
+LEFT	LITERAL1
+RIGHT	LITERAL1
+STOP	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords