### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,24 +5,24 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-MotorControl    KEYWORD1
+MotorControl	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 drive	KEYWORD2
-init    KEYWORD2
+init	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
-DC_Motor    KEYWORD2
+DC_Motor	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-FORWARD LITERAL1
-REVERSE LITERAL1
-LEFT    LITERAL1
-RIGHT   LITERAL1
-STOP    LITERAL1
+FORWARD	LITERAL1
+REVERSE	LITERAL1
+LEFT	LITERAL1
+RIGHT	LITERAL1
+STOP	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords